### PR TITLE
ci: run workflow on different versions of go

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -8,10 +8,15 @@ on:
 jobs:
   check-application:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: ['1.15', '1.20']
+
     steps:
       - uses: actions/checkout@v2 # download from the repo into this ubuntu machine
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: ${{ matrix.go-version }}
       - run: go test
       - run: go run math.go


### PR DESCRIPTION
- the job will run N times, depending on the matrix length
- in this case, it was used to run on different versions, but this is not its only purpose